### PR TITLE
Fixed LIBM target issue and added the missing file gettimeoftheday c

### DIFF
--- a/cmake/modules/CheckDependentLibraries.cmake
+++ b/cmake/modules/CheckDependentLibraries.cmake
@@ -12,13 +12,10 @@ find_package(FLEX REQUIRED)
 
 find_package(BISON REQUIRED)
 
-if(UNIX)
-  find_library(MATH_LIBRARY m)
-  add_library(LIBM INTERFACE IMPORTED GLOBAL)
-  set_property(TARGET LIBM PROPERTY INTERFACE_LINK_LIBRARIES ${MATH_LIBRARY})
-  mark_as_advanced(M_LIBRARY)
-  message("!!! MATH_LIBRARY: ${MATH_LIBRARY}")
-endif()
+find_library(MATH_LIBRARY m)
+add_library(LIBM INTERFACE IMPORTED GLOBAL)
+set_property(TARGET LIBM PROPERTY INTERFACE_LINK_LIBRARIES ${MATH_LIBRARY})
+mark_as_advanced(M_LIBRARY)
 
 find_package(PROJ REQUIRED)
 if(PROJ_FOUND)

--- a/utils/timer/msvc/gettimeofday.c
+++ b/utils/timer/msvc/gettimeofday.c
@@ -1,0 +1,75 @@
+/*
+ * win32gettimeofday.c
+ *	  Win32 gettimeofday() replacement
+ *
+ * src/port/win32gettimeofday.c
+ *
+ * Copyright (c) 2003 SRA, Inc.
+ * Copyright (c) 2003 SKC, Inc.
+ *
+ * Permission to use, copy, modify, and distribute this software and
+ * its documentation for any purpose, without fee, and without a
+ * written agreement is hereby granted, provided that the above
+ * copyright notice and this paragraph and the following two
+ * paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL THE AUTHOR BE LIABLE TO ANY PARTY FOR DIRECT,
+ * INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+ * DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * THE AUTHOR SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+ * A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS
+ * IS" BASIS, AND THE AUTHOR HAS NO OBLIGATIONS TO PROVIDE MAINTENANCE,
+ * SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ */
+
+#include "c.h"
+
+#include <sysinfoapi.h>
+
+#include <sys/time.h>
+
+/* FILETIME of Jan 1 1970 00:00:00, the PostgreSQL epoch */
+static const unsigned __int64 epoch = UINT64CONST(116444736000000000);
+
+/*
+ * FILETIME represents the number of 100-nanosecond intervals since
+ * January 1, 1601 (UTC).
+ */
+#define FILETIME_UNITS_PER_SEC	10000000L
+#define FILETIME_UNITS_PER_USEC 10
+
+
+/*
+ * timezone information is stored outside the kernel so tzp isn't used anymore.
+ *
+ * Note: this function is not for Win32 high precision timing purposes. See
+ * elapsed_time().
+ */
+int
+gettimeofday(struct timeval *tp, void *tzp)
+{
+	FILETIME	file_time;
+	ULARGE_INTEGER ularge;
+
+	/*
+	 * POSIX declines to define what tzp points to, saying "If tzp is not a
+	 * null pointer, the behavior is unspecified".  Let's take this
+	 * opportunity to verify that noplace in Postgres tries to use any
+	 * unportable behavior.
+	 */
+	Assert(tzp == NULL);
+
+	GetSystemTimePreciseAsFileTime(&file_time);
+	ularge.LowPart = file_time.dwLowDateTime;
+	ularge.HighPart = file_time.dwHighDateTime;
+
+	tp->tv_sec = (long) ((ularge.QuadPart - epoch) / FILETIME_UNITS_PER_SEC);
+	tp->tv_usec = (long) (((ularge.QuadPart - epoch) % FILETIME_UNITS_PER_SEC)
+						  / FILETIME_UNITS_PER_USEC);
+
+	return 0;
+}


### PR DESCRIPTION
1. MSVC cmake doesn't find conda libraries with prefix. So, we use conda cmake. 
2. MSVC cmake requires lot of changes to detect conda libraries. But conda cmake detected all conda libraries without any changes.
3. The 2 changes are from the error message LIBM target and the missing gettimeoftheday c file. So, I copied the file from postgresql by following the commit message (add gettimeofday windowss implemenation from postgresql).
4. Conda cmake uses the same target as MSVC cmake (Visual Studio 17 2022).

How to build: `msbuild GRASS.sln`

Currently Fixing MSVC errors